### PR TITLE
(vitineth/delete): adding consensus delete mechanisms

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@uems/micro-builder": "^1.0.3",
-    "@uems/uemscommlib": "0.1.0-beta.38",
+    "@uems/uemscommlib": "0.1.0-beta.44",
     "amqplib": "^0.8.0",
     "colors": "^1.4.0",
     "mongo-unit": "^2.0.1",


### PR DESCRIPTION
This is part of a suite of changes across the network which allow consensus based deletes. On delete a discovery message is sent to every service to return how many entities block the delete and how many would be changed. If no service restricts the delete, a new message is sent to actually perform the deletion.